### PR TITLE
Initial implementation of Prometheus server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+_env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM prom/prometheus
+# We're starting with the official base image, which is Alpine w/ glibc and
+# has WORKDIR set to /prometheus. We'll override the entrypoint and command
+
+RUN apk add --update curl
+
+# get consul-template
+RUN curl -Lso /tmp/consul-template_0.14.0_linux_amd64.zip https://releases.hashicorp.com/consul-template/0.14.0/consul-template_0.14.0_linux_amd64.zip \
+    && echo "7c70ea5f230a70c809333e75fdcff2f6f1e838f29cfb872e1420a63cdf7f3a78" /tmp/consul-template_0.14.0_linux_amd64.zip \
+    && unzip /tmp/consul-template_0.14.0_linux_amd64.zip \
+    && mv consul-template /bin
+
+# get Containerbuddy release
+ENV CONTAINERBUDDY_VERSION 1.3.0
+RUN export CB_SHA1=c25d3af30a822f7178b671007dcd013998d9fae1 \
+    && curl -Lso /tmp/containerbuddy.tar.gz \
+         "https://github.com/joyent/containerbuddy/releases/download/${CONTAINERBUDDY_VERSION}/containerbuddy-${CONTAINERBUDDY_VERSION}.tar.gz" \
+    && echo "${CB_SHA1}  /tmp/containerbuddy.tar.gz" | sha1sum -c \
+    && tar zxf /tmp/containerbuddy.tar.gz -C /bin \
+    && rm /tmp/containerbuddy.tar.gz
+
+# Add Containerbuddy configuration
+COPY etc/containerbuddy.json /etc
+ENV CONTAINERBUDDY file:///etc/containerbuddy.json
+
+# Add Prometheus config template
+# ref https://prometheus.io/docs/operating/configuration/
+# for details on building your own config
+COPY etc/prometheus.yml.ctmpl /etc/prometheus/prometheus.yml.ctmpl
+
+# Override the entrypoint to include Containerbuddy
+ENTRYPOINT []
+CMD ["/bin/containerbuddy", \
+     "/bin/prometheus", \
+     "-config.file=/etc/prometheus/prometheus.yml", \
+     "-storage.local.path=/prometheus", \
+     "-web.console.libraries=/etc/prometheus/console_libraries", \
+     "-web.console.templates=/etc/prometheus/consoles" ]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ Once you have Prometheus running you should be able to check its current status 
 
 
 ```bash
-$ prometheus=$(triton inst get prometheus_prometheus_1 | json -a ips.1)
-$ curl "http://${prometheus}:9090/metrics" | less # there's a lot of data!
+# pipe it to less because there's a lot of data!
+$ curl "http://$(triton ip prometheus_prometheus_1):9090/metrics" | less
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
-# prometheus
-Implementation of the autopilotpattern for a Prometheus.io server
+# Prometheus with the Autopilot Pattern
+
+This repo is an extension of the official [Prometheus.io](https://prometheus.io) Docker image, designed to be self-operating according to the autopilot pattern. This application demonstrates support for configuring Prometheus to be used as a metrics collector for applications using the Containerbuddy metrics endpoint.
+
+### Using Prometheus with Containerbuddy
+
+The Dockerfile provided uses Containerbuddy in the Prometheus container to populate (and keep updated) the Prometheus configuration file with a list of targets.
+
+For targets, Containerbuddy supports a Prometheus-compatible metrics endpoint. If a `metrics` option is provided, Containerbuddy will expose a Prometheus HTTP client interface that can be used to scrape performance metrics. The metrics interface is advertised as a service to the discovery service similar to services configured via the Containerbuddy `services` block. Each sensor for the metrics service will run periodically and record values in the [Prometheus client library](https://github.com/prometheus/client_golang). A Prometheus server can then make HTTP requests to the metrics endpoint.
+
+### Run it!
+
+1. [Get a Joyent account](https://my.joyent.com/landing/signup/) and [add your SSH key](https://docs.joyent.com/public-cloud/getting-started).
+1. Install the [Docker Toolbox](https://docs.docker.com/installation/mac/) (including `docker` and `docker-compose`) on your laptop or other environment, as well as the [Joyent Triton CLI](https://www.joyent.com/blog/introducing-the-triton-command-line-tool) (`triton` replaces our old `sdc-*` CLI tools).
+1. [Configure Docker and Docker Compose for use with Joyent.](https://docs.joyent.com/public-cloud/api-access/docker)
+
+Check that everything is configured correctly by running `./setup.sh`. This will check that your environment is setup correctly and will create an `_env` file that includes injecting an environment variable for the Consul hostname into the Prometheus container so we can take advantage of [Triton Container Name Service (CNS)](https://www.joyent.com/blog/introducing-triton-container-name-service).
+
+```bash
+$ docker-compose up -d
+Creating prometheus_prometheus_1
+Creating prometheus_consul_1
+
+$ docker-compose ps
+Name                         Command           State    Ports
+--------------------------------------------------------------------------------
+prometheus_consul_1          /bin/start -server    Up   53/tcp, 53/udp,
+                             -bootst ...                8300/tcp, 8301/tcp,
+                                                        8301/udp, 8302/tcp,
+                                                        8302/udp, 8400/tcp,
+                                                        0.0.0.0:8500->8500/tcp
+prometheus_prometheus_1      /bin/containerbuddy   Up   0.0.0.0:9090->9090/tcp
+                             /bin/prometheus...
+```
+
+
+Once you have Prometheus running you should be able to check its current status by making an HTTP request to its own metrics endpoint:
+
+
+```bash
+$ prometheus=$(triton inst get prometheus_prometheus_1 | json -a ips.1)
+$ curl "http://${prometheus}:9090/metrics" | less # there's a lot of data!
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+# Prometheus demonstration of the autopilot pattern
+
+prometheus:
+    image: autopilotpattern/prometheus
+    mem_limit: 1g
+    restart: always
+    labels:
+      - triton.cns.services=prometheus
+    ports:
+      - 9090
+    env_file: _env
+
+
+# Start with a single host which will bootstrap the cluster.
+# In production we'll want to use an HA cluster.
+consul:
+    image: progrium/consul:latest
+    restart: always
+    mem_limit: 128m
+    expose:
+      - 53
+      - 8300
+      - 8301
+      - 8302
+      - 8400
+      - 8500
+    dns:
+       - 127.0.0.1
+    labels:
+      - triton.cns.services=consul
+    command: -server -bootstrap -ui-dir /ui

--- a/etc/containerbuddy.json
+++ b/etc/containerbuddy.json
@@ -4,7 +4,7 @@
     {
       "name": "prometheus",
       "port": 9090,
-      "health": ["true"],
+      "health": ["curl", "-so", "/dev/null", "http://localhost:9090/metrics"],
       "poll": 10,
       "ttl": 25
     }

--- a/etc/containerbuddy.json
+++ b/etc/containerbuddy.json
@@ -1,0 +1,22 @@
+{
+  "consul": "{{ .CONSUL }}:8500",
+  "services": [
+    {
+      "name": "prometheus",
+      "port": 9090,
+      "health": ["true"],
+      "poll": 10,
+      "ttl": 25
+    }
+  ],
+  "backends": [
+    {
+      "name": "metrics",
+      "poll": 5,
+      "onChange": [
+        "consul-template", "-once", "-consul", "{{ .CONSUL }}:8500", "-template",
+        "/etc/prometheus/prometheus.yml.ctmpl:/etc/prometheus/prometheus.yml:pkill -HUP prometheus"
+      ]
+    }
+  ]
+}

--- a/etc/prometheus.yml.ctmpl
+++ b/etc/prometheus.yml.ctmpl
@@ -1,0 +1,32 @@
+# my global config
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 15s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+      monitor: 'codelab-monitor'
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  # - "first.rules"
+  # - "second.rules"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+    scrape_timeout: 10s
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    target_groups:
+      - targets: [{{ if service "metrics" }}{{{{ range service "metrics" }}'{{.Address}}:{{.Port}}'{{end}} | join ","}}{{else}}'localhost:9090'{{end}}
+      ]

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -1,0 +1,19 @@
+prometheus:
+    extends:
+      file: docker-compose.yml
+      service: prometheus
+    build: .
+    mem_limit: 128g
+    environment:
+      - CONSUL=consul
+    links:
+      - consul:consul
+    ports:
+      - "9090:9090"
+
+consul:
+    extends:
+      file: docker-compose.yml
+      service: consul
+    ports:
+      - "8500:8500"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+set -e -o pipefail
+
+help() {
+    echo 'Usage ./setup.sh [-f docker-compose.yml] [-p project]'
+    echo
+    echo 'Checks that your Triton and Docker environment is sane and configures'
+    echo 'an environment file to use.'
+    echo
+    echo 'Optional flags:'
+    echo '  -f <filename>   use this file as the docker-compose config file'
+    echo '  -p <project>    use this name as the project prefix for docker-compose'
+}
+
+
+# default values which can be overriden by -f or -p flags
+export COMPOSE_PROJECT_NAME=prometheus
+export COMPOSE_FILE=
+
+# give the docker remote api more time before timeout
+export COMPOSE_HTTP_TIMEOUT=300
+
+# populated by `check` function whenever we're using Triton
+TRITON_USER=
+TRITON_DC=
+TRITON_ACCOUNT=
+
+# ---------------------------------------------------
+# Top-level commmands
+
+
+# Check for correct configuration
+check() {
+
+    command -v docker >/dev/null 2>&1 || {
+        echo
+        tput rev  # reverse
+        tput bold # bold
+        echo 'Docker is required, but does not appear to be installed.'
+        tput sgr0 # clear
+        echo 'See https://docs.joyent.com/public-cloud/api-access/docker'
+        exit 1
+    }
+    command -v json >/dev/null 2>&1 || {
+        echo
+        tput rev  # reverse
+        tput bold # bold
+        echo 'Error! JSON CLI tool is required, but does not appear to be installed.'
+        tput sgr0 # clear
+        echo 'See https://apidocs.joyent.com/cloudapi/#getting-started'
+        exit 1
+    }
+
+    # if we're not testing on Triton, don't bother checking Triton config
+    if [ ! -z "${COMPOSE_FILE}" ]; then
+        exit 0
+    fi
+
+    command -v triton >/dev/null 2>&1 || {
+        echo
+        tput rev  # reverse
+        tput bold # bold
+        echo 'Error! Joyent Triton CLI is required, but does not appear to be installed.'
+        tput sgr0 # clear
+        echo 'See https://www.joyent.com/blog/introducing-the-triton-command-line-tool'
+        exit 1
+    }
+
+    # make sure Docker client is pointed to the same place as the Triton client
+    local docker_user=$(docker info 2>&1 | awk -F": " '/SDCAccount:/{print $2}')
+    local docker_dc=$(echo $DOCKER_HOST | awk -F"/" '{print $3}' | awk -F'.' '{print $1}')
+    TRITON_USER=$(triton profile get | awk -F": " '/account:/{print $2}')
+    TRITON_DC=$(triton profile get | awk -F"/" '/url:/{print $3}' | awk -F'.' '{print $1}')
+    TRITON_ACCOUNT=$(triton account get | awk -F": " '/id:/{print $2}')
+    if [ ! "$docker_user" = "$TRITON_USER" ] || [ ! "$docker_dc" = "$TRITON_DC" ]; then
+        echo
+        tput rev  # reverse
+        tput bold # bold
+        echo 'Error! The Triton CLI configuration does not match the Docker CLI configuration.'
+        tput sgr0 # clear
+        echo
+        echo "Docker user: ${docker_user}"
+        echo "Triton user: ${TRITON_USER}"
+        echo "Docker data center: ${docker_dc}"
+        echo "Triton data center: ${TRITON_DC}"
+        exit 1
+    fi
+
+    local triton_cns_enabled=$(triton account get | awk -F": " '/cns/{print $2}')
+    if [ ! "true" == "$triton_cns_enabled" ]; then
+        echo
+        tput rev  # reverse
+        tput bold # bold
+        echo 'Error! Triton CNS is required and not enabled.'
+        tput sgr0 # clear
+        echo
+        exit 1
+    fi
+
+    echo CONSUL=consul.svc.${TRITON_ACCOUNT}.${TRITON_DC}.cns.joyent.com > _env
+}
+
+# ---------------------------------------------------
+# parse arguments
+
+while getopts "f:p:h" optchar; do
+    case "${optchar}" in
+        f) export COMPOSE_FILE=${OPTARG} ;;
+        p) export COMPOSE_PROJECT_NAME=${OPTARG} ;;
+    esac
+done
+shift $(expr $OPTIND - 1 )
+
+until
+    cmd=$1
+    if [ ! -z "$cmd" ]; then
+        shift 1
+        $cmd "$@"
+        if [ $? == 127 ]; then
+            help
+        fi
+        exit
+    fi
+do
+    echo
+done
+
+# default behavior
+check


### PR DESCRIPTION
@misterbisson this is an in-progress PR for our Prometheus server.

I'm using `consul-template` to re-render the Prometheus configuration file in order to update targets for any container that's advertising on a service named `metrics`. Includes setup script, README, and both local/remote compose file. This doesn't yet include a demonstration metrics target.

The current build has been pushed to the Hub as [autopilotpattern/prometheus:latest](https://hub.docker.com/r/autopilotpattern/prometheus/).

cc @misterbisson 
