### PR TITLE
Use Containerbuddy telemetry release candidate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN curl -Lso /tmp/consul-template_0.14.0_linux_amd64.zip https://releases.hashi
     && mv consul-template /bin
 
 # get Containerbuddy release
-ENV CONTAINERBUDDY_VERSION 1.3.0
-RUN export CB_SHA1=c25d3af30a822f7178b671007dcd013998d9fae1 \
+ENV CONTAINERBUDDY_VERSION 1.4.0-rc1
+RUN export CB_SHA1=8d7c21c8c79c082ec47e956a219cd58206592c83 \
     && curl -Lso /tmp/containerbuddy.tar.gz \
          "https://github.com/joyent/containerbuddy/releases/download/${CONTAINERBUDDY_VERSION}/containerbuddy-${CONTAINERBUDDY_VERSION}.tar.gz" \
     && echo "${CB_SHA1}  /tmp/containerbuddy.tar.gz" | sha1sum -c \

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Prometheus with the Autopilot Pattern
 
-This repo is an extension of the official [Prometheus.io](https://prometheus.io) Docker image, designed to be self-operating according to the autopilot pattern. This application demonstrates support for configuring Prometheus to be used as a metrics collector for applications using the Containerbuddy metrics endpoint.
+This repo is an extension of the official [Prometheus.io](https://prometheus.io) Docker image, designed to be self-operating according to the autopilot pattern. This application demonstrates support for configuring Prometheus to be used as a metrics collector for applications using the Containerbuddy telemetry endpoint.
 
 ### Using Prometheus with Containerbuddy
 
 The Dockerfile provided uses Containerbuddy in the Prometheus container to populate (and keep updated) the Prometheus configuration file with a list of targets.
 
-For targets, Containerbuddy supports a Prometheus-compatible metrics endpoint. If a `metrics` option is provided, Containerbuddy will expose a Prometheus HTTP client interface that can be used to scrape performance metrics. The metrics interface is advertised as a service to the discovery service similar to services configured via the Containerbuddy `services` block. Each sensor for the metrics service will run periodically and record values in the [Prometheus client library](https://github.com/prometheus/client_golang). A Prometheus server can then make HTTP requests to the metrics endpoint.
+For targets, Containerbuddy supports a Prometheus-compatible telemetry endpoint. If a `telemetry` option is provided, Containerbuddy will expose a Prometheus HTTP client interface that can be used to scrape performance telemetry. The telemetry interface is advertised as a service to the discovery service similar to services configured via the Containerbuddy `services` block. Each sensor for the telemetry service will run periodically and record values in the [Prometheus client library](https://github.com/prometheus/client_golang). A Prometheus server can then make HTTP requests to the telemetry endpoint.
 
 ### Run it!
 
@@ -34,10 +34,10 @@ prometheus_prometheus_1      /bin/containerbuddy   Up   0.0.0.0:9090->9090/tcp
 ```
 
 
-Once you have Prometheus running you should be able to check its current status by making an HTTP request to its own metrics endpoint:
+Once you have Prometheus running you should be able to check its current status by making an HTTP request to its own telemetry endpoint:
 
 
 ```bash
 # pipe it to less because there's a lot of data!
-$ curl "http://$(triton ip prometheus_prometheus_1):9090/metrics" | less
+$ curl "http://$(triton ip prometheus_prometheus_1):9090/telemetry" | less
 ```

--- a/etc/containerbuddy.json
+++ b/etc/containerbuddy.json
@@ -11,7 +11,7 @@
   ],
   "backends": [
     {
-      "name": "metrics",
+      "name": "telemetry",
       "poll": 5,
       "onChange": [
         "consul-template", "-once", "-consul", "{{ .CONSUL }}:8500", "-template",

--- a/etc/prometheus.yml.ctmpl
+++ b/etc/prometheus.yml.ctmpl
@@ -24,9 +24,9 @@ scrape_configs:
     scrape_interval: 5s
     scrape_timeout: 10s
 
-    # metrics_path defaults to '/metrics'
+    metrics_path: /telemetry
     # scheme defaults to 'http'.
 
     target_groups:
-      - targets: [{{ if service "metrics" }}{{{{ range service "metrics" }}'{{.Address}}:{{.Port}}'{{end}} | join ","}}{{else}}'localhost:9090'{{end}}
+      - targets: [{{ if service "telemetry" }}{{{{ range service "telemetry" }}'{{.Address}}:{{.Port}}'{{end}} | join ","}}{{else}}'localhost:9090'{{end}}
       ]


### PR DESCRIPTION
@misterbisson this updates our prometheus blueprint to use the Containerbuddy 1.4.0-rc1 release candidate that include telemetry.
