### PR TITLE
Pin to 0.17.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM prom/prometheus
+FROM prom/prometheus:0.18.0
 # We're starting with the official base image, which is Alpine w/ glibc and
 # has WORKDIR set to /prometheus. We'll override the entrypoint and command
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM prom/prometheus:0.18.0
+FROM prom/prometheus:0.17.0
 # We're starting with the official base image, which is Alpine w/ glibc and
 # has WORKDIR set to /prometheus. We'll override the entrypoint and command
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Prometheus demonstration of the autopilot pattern
 
 prometheus:
-    image: autopilotpattern/prometheus
+    image: autopilotpattern/prometheus:latest
     mem_limit: 1g
     restart: always
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Prometheus demonstration of the autopilot pattern
 
 prometheus:
-    image: autopilotpattern/prometheus:latest
+    image: autopilotpattern/prometheus:0.17.0-r1
     mem_limit: 1g
     restart: always
     labels:

--- a/etc/containerbuddy.json
+++ b/etc/containerbuddy.json
@@ -1,5 +1,9 @@
 {
   "consul": "{{ .CONSUL }}:8500",
+  "onStart": [
+    "consul-template", "-once", "-consul", "{{ .CONSUL }}:8500", "-template",
+    "/etc/prometheus/prometheus.yml.ctmpl:/etc/prometheus/prometheus.yml"
+  ],
   "services": [
     {
       "name": "prometheus",

--- a/etc/prometheus.yml.ctmpl
+++ b/etc/prometheus.yml.ctmpl
@@ -24,7 +24,7 @@ scrape_configs:
     scrape_interval: 5s
     scrape_timeout: 10s
 
-    metrics_path: /telemetry
+    metrics_path: /metrics
     # scheme defaults to 'http'.
 
     target_groups:


### PR DESCRIPTION
The original image was built based on an implied `:latest` tag and won't rebuild now on the current `:latest`. Tags: https://hub.docker.com/r/prom/prometheus/tags/, `:latest` now is 1.0.1, per https://microbadger.com/#/images/prom/prometheus.

This pins it to `:0.17.0` which was the `:latest` at the time, so that we can build a working version name. Separately, https://github.com/autopilotpattern/prometheus/issues/8 seeks to update everything.

The resulting image will be tagged `:autopilotpattern/prometheus:0.17.0-r1` and `:latest`, and replace the existing Docker Hub image.
