### PR TITLE
Update Prometheus to 1.3, ContainerPilot to 2.4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,56 @@
-FROM prom/prometheus:0.17.0
-# We're starting with the official base image, which is Alpine w/ glibc and
-# has WORKDIR set to /prometheus. We'll override the entrypoint and command
+FROM alpine:3.4
+
+# The official Promtheus base image has no package manager so rather than
+# artisanally hand-rolling curl and the rest of our stack we'll just use
+# Alpine so we can use `docker build`.
 
 RUN apk add --update curl
+
+# add Prometheus. alas, the Prometheus developers provide no checksum
+RUN export prom=prometheus-1.3.0.linux-amd64 \
+    && curl -Lso /tmp/${prom}.tar.gz https://github.com/prometheus/prometheus/releases/download/v1.3.0/${prom}.tar.gz \
+    && tar zxf /tmp/${prom}.tar.gz -C /tmp \
+    && mkdir /etc/prometheus /usr/share/prometheus \
+    && mv /tmp/${prom}/prometheus /bin/prometheus \
+    && mv /tmp/${prom}/promtool /bin/promtool \
+    && mv /tmp/${prom}/prometheus.yml /etc/prometheus/ \
+    && mv /tmp/${prom}/consoles /usr/share/prometheus/consoles \
+    && mv /tmp/${prom}/console_libraries /usr/share/prometheus/console_libraries \
+    && ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/ \
+    && rm /tmp/prometheus-1.3.0.linux-amd64.tar.gz
 
 # get consul-template
 RUN curl -Lso /tmp/consul-template_0.14.0_linux_amd64.zip https://releases.hashicorp.com/consul-template/0.14.0/consul-template_0.14.0_linux_amd64.zip \
     && echo "7c70ea5f230a70c809333e75fdcff2f6f1e838f29cfb872e1420a63cdf7f3a78" /tmp/consul-template_0.14.0_linux_amd64.zip \
     && unzip /tmp/consul-template_0.14.0_linux_amd64.zip \
-    && mv consul-template /bin
+    && mv consul-template /bin \
+    && rm /tmp/consul-template_0.14.0_linux_amd64.zip
 
-# get Containerbuddy release
-ENV CONTAINERBUDDY_VERSION 1.4.0-rc1
-RUN export CB_SHA1=8d7c21c8c79c082ec47e956a219cd58206592c83 \
-    && curl -Lso /tmp/containerbuddy.tar.gz \
-         "https://github.com/joyent/containerbuddy/releases/download/${CONTAINERBUDDY_VERSION}/containerbuddy-${CONTAINERBUDDY_VERSION}.tar.gz" \
-    && echo "${CB_SHA1}  /tmp/containerbuddy.tar.gz" | sha1sum -c \
-    && tar zxf /tmp/containerbuddy.tar.gz -C /bin \
-    && rm /tmp/containerbuddy.tar.gz
+# Add Containerpilot and set its configuration
+ENV CONTAINERPILOT_VERSION 2.4.4
+ENV CONTAINERPILOT file:///etc/containerpilot.json
 
-# Add Containerbuddy configuration
-COPY etc/containerbuddy.json /etc
-ENV CONTAINERBUDDY file:///etc/containerbuddy.json
+RUN export CONTAINERPILOT_CHECKSUM=6194ee482dae95844046266dcec2150655ef80e9 \
+    && export archive=containerpilot-${CONTAINERPILOT_VERSION}.tar.gz \
+    && curl -Lso /tmp/${archive} \
+         "https://github.com/joyent/containerpilot/releases/download/${CONTAINERPILOT_VERSION}/${archive}" \
+    && echo "${CONTAINERPILOT_CHECKSUM}  /tmp/${archive}" | sha1sum -c \
+    && tar zxf /tmp/${archive} -C /usr/local/bin \
+    && rm /tmp/${archive}
+
+# Add Containerpilot configuration
+COPY etc/containerpilot.json /etc
+ENV CONTAINERPILOT file:///etc/containerpilot.json
 
 # Add Prometheus config template
 # ref https://prometheus.io/docs/operating/configuration/
 # for details on building your own config
 COPY etc/prometheus.yml.ctmpl /etc/prometheus/prometheus.yml.ctmpl
 
-# Override the entrypoint to include Containerbuddy
+# Override the entrypoint to include Containerpilot
+WORKDIR /prometheus
 ENTRYPOINT []
-CMD ["/bin/containerbuddy", \
+CMD ["/usr/local/bin/containerpilot", \
      "/bin/prometheus", \
      "-config.file=/etc/prometheus/prometheus.yml", \
      "-storage.local.path=/prometheus", \

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ This repo is an extension of the official [Prometheus.io](https://prometheus.io)
 [![DockerPulls](https://img.shields.io/docker/pulls/autopilotpattern/prometheus.svg)](https://registry.hub.docker.com/u/autopilotpattern/prometheus/)
 [![DockerStars](https://img.shields.io/docker/stars/autopilotpattern/prometheus.svg)](https://registry.hub.docker.com/u/autopilotpattern/prometheus/)
 
-### Using Prometheus with Containerbuddy
+### Using Prometheus with ContainerPilot
 
-The Dockerfile provided uses Containerbuddy in the Prometheus container to populate (and keep updated) the Prometheus configuration file with a list of targets.
+The Dockerfile provided uses ContainerPilot in the Prometheus container to populate (and keep updated) the Prometheus configuration file with a list of targets.
 
-For targets, Containerbuddy supports a Prometheus-compatible telemetry endpoint. If a `telemetry` option is provided, Containerbuddy will expose a Prometheus HTTP client interface that can be used to scrape performance telemetry. The telemetry interface is advertised as a service to the discovery service similar to services configured via the Containerbuddy `services` block. Each sensor for the telemetry service will run periodically and record values in the [Prometheus client library](https://github.com/prometheus/client_golang). A Prometheus server can then make HTTP requests to the telemetry endpoint.
+For targets, ContainerPilot supports a Prometheus-compatible telemetry endpoint. If a `telemetry` option is provided, ContainerPilot will expose a Prometheus HTTP client interface that can be used to scrape performance telemetry. The telemetry interface is advertised as a service to the discovery service similar to services configured via the ContainerPilot `services` block. Each sensor for the telemetry service will run periodically and record values in the [Prometheus client library](https://github.com/prometheus/client_golang). A Prometheus server can then make HTTP requests to the telemetry endpoint.
 
 ### Run it!
 
@@ -32,7 +32,7 @@ prometheus_consul_1          /bin/start -server    Up   53/tcp, 53/udp,
                                                         8301/udp, 8302/tcp,
                                                         8302/udp, 8400/tcp,
                                                         0.0.0.0:8500->8500/tcp
-prometheus_prometheus_1      /bin/containerbuddy   Up   0.0.0.0:9090->9090/tcp
+prometheus_prometheus_1      /bin/containerpilot   Up   0.0.0.0:9090->9090/tcp
                              /bin/prometheus...
 ```
 

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -1,6 +1,6 @@
 {
   "consul": "{{ .CONSUL }}:8500",
-  "onStart": [
+  "preStart": [
     "consul-template", "-once", "-consul", "{{ .CONSUL }}:8500", "-template",
     "/etc/prometheus/prometheus.yml.ctmpl:/etc/prometheus/prometheus.yml"
   ],

--- a/etc/prometheus.yml.ctmpl
+++ b/etc/prometheus.yml.ctmpl
@@ -22,12 +22,11 @@ scrape_configs:
 
     # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 5s
-    scrape_timeout: 10s
 
     metrics_path: /metrics
     # scheme defaults to 'http'.
 
-    target_groups:
+    static_configs:
     {{ if service "containerpilot" }} - targets: [{{range $i, $e := service "containerpilot"}}{{if ne $i 0}},{{end}}'{{$e.Address}}:{{$e.Port}}'{{end}},'localhost:9090']
     {{ else }} - targets: ['localhost:9090']
     {{ end }}


### PR DESCRIPTION
This will enable the work in #5, #8.

The official Prometheus image has been hand-rolled from Busybox and they install the binaries as part of their CI system rather than `curl`ing them in. This has the side effect of there being no package manager in the container. So rather than doing the same for all our binaries (including `curl`), this switches us over to using Alpine and installs the precompiled binaries from GitHub.