### PR TITLE
Quick doc fix under Triton example

### DIFF
--- a/examples/triton/README.md
+++ b/examples/triton/README.md
@@ -16,5 +16,5 @@ See the [README](../../README.md) for details on environment variables in `_env`
 Start everything:
 
 ```bash
-triton-docker up -d
+triton-compose up -d
 ```


### PR DESCRIPTION
Swapping `triton-docker` command to `triton-compose` under the Triton example.

/cc @geek 